### PR TITLE
Replace MariaDB with MySQL for RDS compatibility

### DIFF
--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -55,14 +55,14 @@ services:
     restart: unless-stopped
 
   mariadb:
-    image: mirror.gcr.io/bitnami/mariadb:latest
+    image: mirror.gcr.io/library/mysql:8.0
     environment:
-      MARIADB_USER: ${DB_USER:-drupal}
-      MARIADB_PASSWORD: ${DB_PASSWORD:?Database password required}
-      MARIADB_DATABASE: ${DB_NAME:-drupal}
-      MARIADB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:?Root password required}
+      MYSQL_USER: ${DB_USER:-drupal}
+      MYSQL_PASSWORD: ${DB_PASSWORD:?Database password required}
+      MYSQL_DATABASE: ${DB_NAME:-drupal}
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:?Root password required}
     volumes:
-      - mariadb_data:/bitnami/mariadb
+      - mariadb_data:/var/lib/mysql
     restart: unless-stopped
 
 volumes:

--- a/compose.yaml
+++ b/compose.yaml
@@ -57,14 +57,14 @@ services:
       - minio
 
   mariadb:
-    image: mirror.gcr.io/bitnami/mariadb:latest
+    image: mirror.gcr.io/library/mysql:8.0
     environment:
-      MARIADB_USER: drupal
-      MARIADB_PASSWORD: drupal
-      MARIADB_DATABASE: drupal
-      MARIADB_ROOT_PASSWORD: root
+      MYSQL_USER: drupal
+      MYSQL_PASSWORD: drupal
+      MYSQL_DATABASE: drupal
+      MYSQL_ROOT_PASSWORD: root
     volumes:
-      - mariadb_data:/bitnami/mariadb
+      - mariadb_data:/var/lib/mysql
 
   minio:
     image: minio/minio:latest


### PR DESCRIPTION
- Change database image from bitnami/mariadb to official mysql:8.0
- Update environment variables from MARIADB_* to MYSQL_*
- Change data volume path from /bitnami/mariadb to /var/lib/mysql
- Use MySQL 8.0 for stability (latest 9.3.0 had initialization issues)

This change improves compatibility with AWS RDS for MySQL in production while maintaining minimal differences between development and production environments.

🤖 Generated with [Claude Code](https://claude.ai/code)